### PR TITLE
re-added an optional timeout for wait_read_frame, as in @thom-nic 's …

### DIFF
--- a/xbee/backend/base.py
+++ b/xbee/backend/base.py
@@ -18,6 +18,9 @@ from xbee.python2to3 import byteToInt, stringToBytes
 class CommandFrameException(KeyError):
     pass
 
+class TimeoutException(Exception):
+    pass
+
 
 class XBeeBase(object):
     """

--- a/xbee/thread/base.py
+++ b/xbee/thread/base.py
@@ -13,14 +13,12 @@ series-specific functionality.
 """
 from xbee.frame import APIFrame
 from xbee.backend.base import XBeeBase as _XBeeBase
+from xbee.backend.base import TimeoutException as _TimeoutException
 import threading
 import time
 
 
 class ThreadQuitException(Exception):
-    pass
-
-class TimeoutException(Exception):
     pass
 
 
@@ -132,7 +130,7 @@ class XBeeBase(_XBeeBase):
 
                 if self.serial.inWaiting() == 0:
                     if deadline and time.time() > deadline:
-                        raise TimeoutException
+                        raise _TimeoutException
                     time.sleep(.01)
                     continue
 


### PR DESCRIPTION
this re-adds lost support for a timeout in wait_read_frame and is based on @thom-nic 's version of python-xbee, the timeout only raises a TimeoutException before a frame-Startbyte is received