### PR TITLE
reverting tornado change on extras_require

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,6 @@ setup(
     packages=find_packages(exclude=['tests', '*.tests']),
     install_requires=['pyserial'],
     extras_require={
-        'tornado': ['tornado~=4.5']
+        'tornado': ['tornado']
     }
 )


### PR DESCRIPTION
hopefully resolving https://github.com/niolabs/python-xbee/issues/66

@bp1222 I wasn't sure why you included the specific version constraint on Tornado, but it wasn't coming through cleanly for me - if this isn't the correct fix, please holler and I'll update or close the PR as is appropriate.