### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -84,6 +84,8 @@ Dependencies
 ============
 
 PySerial
+pip >= 6.0
+setuptools >= 8.0
 
 Additional Dependencies
 -----------------------


### PR DESCRIPTION
Problem for some currently supported linux distros (specifically Ubuntu 14.04 LTS) ship with pip 1.5.3 and setuptools 2.x.  Both of these pre-date the support of tilde-versioning.  Adding docs for minimum supported versions of both.